### PR TITLE
Added script pullcx to pull all repositories.

### DIFF
--- a/pullcx
+++ b/pullcx
@@ -1,0 +1,6 @@
+set -x
+git pull
+git -C input pull
+git -C src/bgc pull
+git -C src/vilma pull
+git -C src/yelmo pull


### PR DESCRIPTION
Run `./pullcx` and `git pull` will be performed on the climber-x directory and all dependent repositories. Note will only pull whatever the current active branch is.