### PR TITLE
Move `include config/common.mk` into the Makefile template

### DIFF
--- a/config/Makefile
+++ b/config/Makefile
@@ -13,9 +13,21 @@ openmp_yelmo ?= $(openmp)
 defaulttarget: usage
 
 ## COMPILER CONFIGURATION ##
-# (should be loaded from config directory)
+# Loaded from a config/<host> fragment by `python config.py config/<host>`,
+# or assembled by `configme` in the modern path. The fragment defines the
+# compiler (FC, FFLAGS_BASE, FFLAGS_OPENMP, CPPFLAGS_PP, DFLAGS_*), netCDF
+# wiring (INC_NC, LIB_NC), and any host-specific overrides (e.g. LFLAGS_EXTRA).
 
 <COMPILER_CONFIGURATION>
+
+## SHARED DEPENDENCY WIRING ##
+# Pulled in after the compiler/machine fragment so it can reference FFLAGS_BASE,
+# FFLAGS_OPENMP, CPPFLAGS_PP, INC_NC, LIB_NC, and LFLAGS_EXTRA set there.
+# Defines the COORD, FESMUTILS, FFTW, LIS, YELMO, and (optional) VILMA paths,
+# the openmp= build switch, and the final FFLAGS_CLIM/FFLAGS_FULL and
+# LFLAGS_CLIM/LFLAGS_FULL flag sets.
+
+include config/common.mk
 
 ## gitversion
 # generate a Git version string


### PR DESCRIPTION
## Summary

- Add `include config/common.mk` to `config/Makefile` so the shared dependency wiring is pulled in by the template itself.
- Matches the new configme convention from configme commit `0d74766` ("Stop inlining common.mk; let the template's own include pull it in") and mirrors yelmo's change in `7ce9c90b`.
- `config/common.mk` itself was already present (added in `55814b9`); only the template was missing the include line, so every `configme` run was at risk of drifting from the file.

## Test plan

- [ ] Re-run `configme` and confirm the regenerated `Makefile` contains a single `include config/common.mk` instead of an inlined dependency-wiring block.
- [ ] `make climber-clim` builds on macbook (gfortran).
- [ ] `make climber` (full clim+bgc+ice variant) builds on a PIK host.