### PR TITLE
yelmo: H_w rename to hyd_W_til, now using internal hydrology model

### DIFF
--- a/src/ice/ice_model.f90
+++ b/src/ice/ice_model.f90
@@ -983,7 +983,7 @@ contains
                       dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
         call nc_write(filename,"f_pmp",ylmo%thrm%now%f_pmp,units="1",long_name="Fraction of grid point at pmp", &
                       dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
-        call nc_write(filename,"H_w",ylmo%thrm%now%H_w,units="m water equiv.",long_name="Basal water layer thickness", &
+        call nc_write(filename,"hyd_W_til",ylmo%hyd%now%W_til,units="m water equiv.",long_name="Basal till water layer thickness", &
                       dim1="xc",dim2="yc",dim3="time",start=[1,1,n],ncid=ncid)
         
         ! Close the netcdf file


### PR DESCRIPTION
ylmo%thrm%now%H_w no longer exists; basal water is now tracked by the hyd (FastHydrology) component. Write ylmo%hyd%now%W_til as variable hyd_W_til, matching the naming used in yelmo_io.f90.