### PR TITLE
yelmo/FastHydrology linking bug fixed.

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -43,7 +43,7 @@ LIB_YELMO = -L${YELMOROOT}/libyelmo/include -lyelmo
 # the fasthydro .mod files and libyelmo.a references libfasthydro symbols).
 # Built into a single include/ dir (no serial/omp split). FastHydrology itself
 # pulls in FFTW, which is already wired above.
-FASTHYDROROOT = FastHydrology
+FASTHYDROROOT = yelmo/FastHydrology
 INC_FASTHYDRO = -I${FASTHYDROROOT}/include
 LIB_FASTHYDRO = -L${FASTHYDROROOT}/include -lfasthydro
 


### PR DESCRIPTION
FastHydrology was moved from the climber-x root into yelmo/FastHydrology (configme configures it there, transitively via yelmo v2.2). Point FASTHYDROROOT at the new location so INC_FASTHYDRO and LIB_FASTHYDRO resolve; fixes 'ld: cannot find -lfasthydro' at the final climber.x link.