### PR TITLE
Fix uninitialised k_bmb/nk in ocn_to_cmn (segfault on non-soy ocn steps)

### DIFF
--- a/src/main/coupler.f90
+++ b/src/main/coupler.f90
@@ -1018,9 +1018,14 @@ contains
 
 
     ! find index of top 1 km ocean layers for basal melt
-    if (flag_bmb .and. time_soy_ocn) then
+    ! NOTE: k_bmb/nk must be set on every call (the omp loop below uses them
+    ! whenever flag_bmb), not only at start-of-year, otherwise they are read
+    ! uninitialised on non-soy steps -> out-of-bounds slicing / segfault.
+    if (flag_bmb) then
       k_bmb = minloc(abs(ocn%grid%zro+1000._wp),1)
       nk = ocn%grid%nk - k_bmb + 1
+    endif
+    if (flag_bmb .and. time_soy_ocn) then
       if (allocated(cmn%z_ocn_bmb))    deallocate(cmn%z_ocn_bmb)
       if (allocated(cmn%mask_ocn_bmb)) deallocate(cmn%mask_ocn_bmb)
       if (allocated(cmn%t_ocn_bmb))    deallocate(cmn%t_ocn_bmb)


### PR DESCRIPTION
In coupler ocn_to_cmn, the scalars k_bmb and nk were computed only inside the `if (flag_bmb .and. time_soy_ocn)` allocation guard, but the OpenMP loop reads them whenever flag_bmb is true. On any non-start-of-year ocean step they were therefore read uninitialised, so the basal-melt slices
  cmn%t_ocn_bmb(i,j,1:nk) = ocn%ts(i,j,ocn%grid%nk:k_bmb:-1,1)
addressed out of bounds, corrupting the heap. This manifested as an intermittent -Ofast-only segfault right after the first ocean year (benign at -O0, a classic undefined-behaviour Heisenbug).

Compute k_bmb/nk unconditionally when flag_bmb (they are constant and cheap); keep the array (de)allocation under the start-of-year guard. Verified: the -Ofast coupled LGM NH-16KM run now clears ocn_to_cmn and advances to the geo solve instead of crashing.